### PR TITLE
wait to close connection

### DIFF
--- a/application/server.go
+++ b/application/server.go
@@ -55,13 +55,13 @@ func uriSchemeSupported(scheme string) bool {
 
 func (s *Server) Run() {
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
 	mux.Handle("/", promhttp.InstrumentHandlerCounter(
 		promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "http_requests_total",
 		}, []string{"code"}),
 		s,
 	))
+	mux.Handle("/metrics", promhttp.Handler())
 	server := &http.Server{
 		Addr:    ":" + s.port,
 		Handler: mux,

--- a/application/server.go
+++ b/application/server.go
@@ -1,11 +1,15 @@
 package application
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"net/url"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"cloudeng.io/net/http/httperror"
 	"github.com/gidoichi/ical-converter/application/datasource"
@@ -29,7 +33,7 @@ func NewServer(convertService convertService, icsURL, port string) (Server, erro
 		return Server{}, fmt.Errorf("failed to parse url: %w", err)
 	}
 	if !uriSchemeSupported(location.Scheme) {
-		return Server{}, fmt.Errorf("unsupported scheme: %s", location.Scheme)
+		return Server{}, fmt.Errorf("unsupported scheme: %#v", location.Scheme)
 	}
 
 	return Server{
@@ -50,15 +54,28 @@ func uriSchemeSupported(scheme string) bool {
 }
 
 func (s *Server) Run() {
-	http.Handle("/", promhttp.InstrumentHandlerCounter(
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/", promhttp.InstrumentHandlerCounter(
 		promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "http_requests_total",
 		}, []string{"code"}),
 		s,
 	))
+	server := &http.Server{
+		Addr:    ":" + s.port,
+		Handler: mux,
+	}
+	go func() {
+		log.Println(server.ListenAndServe())
+	}()
 
-	http.Handle("/metrics", promhttp.Handler())
-	log.Fatal(http.ListenAndServe(":"+s.port, nil))
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+	if err := server.Shutdown(context.Background()); err != nil {
+		log.Fatalf("failed to shutdown server: %v", err)
+	}
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Current main branch code:

```
(main)$ go build && PORT=8080 ICAL_CONVERTER_ICS_URL="https://example.com" ./ical-converter &
[1] 22177

(main)$ pid=$!

(main)$ curl -v localhost:8080 &
[2] 22310
*   Trying 127.0.0.1:8080...                                                                                                         * Connected to localhost (127.0.0.1) port 8080 (#0)
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.81.0
> Accept: */*
> 
2024/03/09 13:20:32 &{Method:GET URL:/ Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Accept:[*/*] User-Agent:[curl/7.81.0]] Body:{} GetBody:<nil> ContentLength:0 TransferEncoding:[] Close:false Host:localhost:8080 Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr:127.0.0.1:54812 RequestURI:/ TLS:<nil> Cancel:<nil> Response:<nil> ctx:0xc000152dc0 pat:0xc000134720 matches:[] otherValues:map[]}

(main)$ kill -SIGTERM $pid
* Empty reply from server                                                                                                            [1]  - 22177 terminated  PORT=8080 ICAL_CONVERTER_ICS_URL="https://example.com" ./ical-converter
* Closing connection 0
curl: (52) Empty reply from server
[2]  + 22310 exit 52    curl -v localhost:8080
```